### PR TITLE
Fix config flow not working

### DIFF
--- a/custom_components/github_copilot/config_flow.py
+++ b/custom_components/github_copilot/config_flow.py
@@ -78,7 +78,7 @@ class GitHubCopilotFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> GitHubCopilotOptionsFlow:
         """Get the options flow for this handler."""
-        return GitHubCopilotOptionsFlow(config_entry)
+        return GitHubCopilotOptionsFlow()
 
     async def async_step_user(
         self,
@@ -268,10 +268,6 @@ class GitHubCopilotFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
 class GitHubCopilotOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for GitHub Copilot integration."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self,


### PR DESCRIPTION
This PR fixes the Home Assistant options/config flow initialization that was causing the flow to fail.

**Root Cause**
The options flow class used a custom constructor and was instantiated with a config entry argument, which does not match the expected Home Assistant OptionsFlow initialization pattern.

**Fix**
Removed the custom constructor from the options flow class.
Updated options flow creation to use the default no-argument instantiation so Home Assistant can manage the flow lifecycle correctly.

**Result**
The config/options flow now opens and works correctly in Home Assistant.

Closes #182 